### PR TITLE
Added support for weighted graphs on Kahn's algorithm

### DIFF
--- a/algorithms/Kahn.js
+++ b/algorithms/Kahn.js
@@ -14,7 +14,7 @@ class Kahn extends Algorithm {
         this.graph = graph
         this.kahnAlgorithm(graph)
         this.removedEdges.forEach(edge => {
-            graph.addEdge(edge.u, edge.v, 1)
+            graph.addEdge(edge.u, edge.v, edge.w)
         })
     }
 
@@ -31,8 +31,10 @@ class Kahn extends Algorithm {
             let u = queue.dequeue()
             this.output.visited_nodes.push(u)
             graph.getAdjacentTo(u).forEach(v => {
+                let w = graph.getWeight(u,v)
+                this.removedEdges.push({u, v, w})
                 graph.removeEdge(u, v)
-                this.removedEdges.push({u, v})
+
                 if (this.hasNoPredecesor(v, graph)) queue.enqueue(v)
             })
         }

--- a/data_structures/Graph.js
+++ b/data_structures/Graph.js
@@ -6,7 +6,7 @@ import {LinkedList} from './LinkedList.js'
 
 class Graph {
 
-    constructor (name) 
+    constructor (name)
     {
         this.name = name
         this.nodes     = []
@@ -64,7 +64,7 @@ class Graph {
 
     addVertex ()
     {
-        
+
         let newNode = new Node ('N' + ++this.edgeIdCounter)
         this.nodes.push (newNode)
 
@@ -133,11 +133,20 @@ class Graph {
         this.insMatrix.set (n1_index,n2_index, weight || 1)
     }
 
+    getWeight(n1, n2)
+    {
+        var n1_index = this.nodes.indexOf(n1)
+        var n2_index = this.nodes.indexOf(n2)
+
+        return this.insMatrix.get(n1_index,n2_index)
+    }
+
+
     areAdjacent (n1,n2)
-    {      
-        //return this.adjList [this.nodes.indexOf (n1)].has(n2) || !this.directed && this.adjList [this.nodes.indexOf (n2)].has(n1)  
-        let index1 = this.nodes.indexOf (n1) 
-        let index2 = this.nodes.indexOf (n2) 
+    {
+        //return this.adjList [this.nodes.indexOf (n1)].has(n2) || !this.directed && this.adjList [this.nodes.indexOf (n2)].has(n1)
+        let index1 = this.nodes.indexOf (n1)
+        let index2 = this.nodes.indexOf (n2)
         return this.directed ? this.insMatrix.get (index1,index2) >= 1 : this.insMatrix.get (index1,index2) >= 1 || this.insMatrix.get (index2,index1) >= 1
     }
 
@@ -180,10 +189,10 @@ class Graph {
 }
 
 class Node {
-    constructor (id) 
+    constructor (id)
     {
         this.value = undefined
-        this.id = id 
+        this.id = id
     }
 }
 export {Graph}


### PR DESCRIPTION
I've added a getWeight method in Graph class to make it easier getting an edge's weight and I've made minor modifications in Kahn's algorithm to reconstruct the edges with their saved weights. Now the algorithm can be performed on weighted graphs.